### PR TITLE
feat: replace ChatScreen padding by MessagesListTile padding

### DIFF
--- a/example/lib/ui/chat_screen.dart
+++ b/example/lib/ui/chat_screen.dart
@@ -195,24 +195,22 @@ class _ChatScreenSate extends State<ChatScreen> with TickerProviderStateMixin {
             titleBuilder: null);
 
     return Expanded(
-        child: Padding(
-            padding: EdgeInsets.all(16),
-            child: MessagesList(
-                controller: _controller,
-                appUserId: _currentUser.id,
-                useCustomTile: (i, item, pos) {
-                  final msg = item as ChatMessage;
-                  return msg.isTypeEvent;
-                },
-                messagePosition: _messagePosition,
-                builders: MessageTileBuilders(
-                    customTileBuilder: _buildEventMessage,
-                    customDateBuilder: _buildDate,
-                    incomingMessageBuilders: incomingBuilders,
-                    outgoingMessageBuilders: OutgoingMessageTileBuilders(
-                        bodyBuilder: (context, index, item, messagePosition) =>
-                            _buildMessageBody(context, index, item,
-                                messagePosition, MessageFlow.outgoing))))));
+        child: MessagesList(
+            controller: _controller,
+            appUserId: _currentUser.id,
+            useCustomTile: (i, item, pos) {
+              final msg = item as ChatMessage;
+              return msg.isTypeEvent;
+            },
+            messagePosition: _messagePosition,
+            builders: MessageTileBuilders(
+                customTileBuilder: _buildEventMessage,
+                customDateBuilder: _buildDate,
+                incomingMessageBuilders: incomingBuilders,
+                outgoingMessageBuilders: OutgoingMessageTileBuilders(
+                    bodyBuilder: (context, index, item, messagePosition) =>
+                        _buildMessageBody(context, index, item, messagePosition,
+                            MessageFlow.outgoing)))));
   }
 
   /// Override [MessagePosition] to return [MessagePosition.isolated] when

--- a/lib/src/widgets/core/messages_list.dart
+++ b/lib/src/widgets/core/messages_list.dart
@@ -118,7 +118,6 @@ class _MessagesListState<T extends MessageBase> extends State<MessagesList> {
   /// It will vary depending on the [MessagePosition]
   double _bottomItemPadding(int index, MessagePosition messagePosition) {
     double padding = 8.0;
-    if (index == 0) return 0;
     if (messagePosition == MessagePosition.surrounded ||
         messagePosition == MessagePosition.surroundedBot) return 1.0;
     return padding;
@@ -185,6 +184,8 @@ class _MessagesListState<T extends MessageBase> extends State<MessagesList> {
           style: widget.style ??
               MessageStyle(
                   padding: EdgeInsets.only(
+                      left: 16,
+                      right: 16,
                       top: _topItemPadding(index, _position),
                       bottom: _bottomItemPadding(index, _position))),
           messagePosition: _position),


### PR DESCRIPTION
This PR moves the padding from top-level to message level so the scroll view can take up the full width and height.